### PR TITLE
Retire js 3.0.3 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.h3xstream.retirejs</groupId>
     <artifactId>retirejs-root-pom</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3</version>
 
     <packaging>pom</packaging>
 
@@ -221,9 +221,9 @@
 
             <!-- Log4J -->
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.13.3</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -181,9 +181,9 @@
             <!-- JSON parser use by the core -->
 
             <dependency>
-                <groupId>org.json</groupId>
-                <artifactId>json</artifactId>
-                <version>20190722</version>
+                <groupId>com.vaadin.external.google</groupId>
+                <artifactId>android-json</artifactId>
+                <version>0.0.20131108.vaadin1</version>
             </dependency>
 
             <!-- ZAP stuff -->

--- a/retirejs-burp-plugin/pom.xml
+++ b/retirejs-burp-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/retirejs-burp-plugin/src/main/java/burp/BurpExtender.java
+++ b/retirejs-burp-plugin/src/main/java/burp/BurpExtender.java
@@ -133,7 +133,7 @@ public class BurpExtender implements IBurpExtender, IScannerCheck {
         return -1; //Unknown
     }
 
-    private List<IScanIssue> scanJavaScript(byte[] respBytes, int offset, String scriptName, IHttpRequestResponse resp, IRequestInfo requestInfo) throws IOException {
+    private List<IScanIssue> scanJavaScript(byte[] respBytes, int offset, String scriptName, IHttpRequestResponse resp, IRequestInfo requestInfo) throws IOException, JSONException {
 
         List<JsLibraryResult> res = ScannerFacade.getInstance().scanScript(scriptName, respBytes, offset);
 
@@ -146,7 +146,7 @@ public class BurpExtender implements IBurpExtender, IScannerCheck {
         return new ArrayList<IScanIssue>(); //Nothing was found
     }
 
-    private List<IScanIssue> scanHtmlPage(byte[] respBytes, int offset, String scriptName, IHttpRequestResponse resp, IRequestInfo requestInfo) throws IOException {
+    private List<IScanIssue> scanHtmlPage(byte[] respBytes, int offset, String scriptName, IHttpRequestResponse resp, IRequestInfo requestInfo) throws IOException, JSONException {
 
         List<JsLibraryResult> res = ScannerFacade.getInstance().scanHtml(respBytes,offset);
 

--- a/retirejs-burp-plugin/src/main/java/burp/BurpExtender.java
+++ b/retirejs-burp-plugin/src/main/java/burp/BurpExtender.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
+import org.json.JSONException;
 
 public class BurpExtender implements IBurpExtender, IScannerCheck {
 
@@ -64,7 +65,7 @@ public class BurpExtender implements IBurpExtender, IScannerCheck {
 
         try {
             ScannerFacade.loadInstance(new VulnerabilitiesRepositoryLoader().load(VulnerabilitiesRepositoryLoader.REPO_URL,new BurpUpstreamDownloader(this.callbacks)));
-        } catch (IOException e) {
+        } catch (IOException | JSONException e) {
             Log.error("ERROR: Problem occurs while preloading the RetireJS vulnerabilities",e);
         }
 

--- a/retirejs-core/pom.xml
+++ b/retirejs-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>

--- a/retirejs-core/pom.xml
+++ b/retirejs-core/pom.xml
@@ -17,8 +17,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
+            <groupId>com.vaadin.external.google</groupId>
+            <artifactId>android-json</artifactId>
         </dependency>
 
         <dependency>

--- a/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/ScannerFacade.java
+++ b/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/ScannerFacade.java
@@ -8,12 +8,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.json.JSONException;
 
 public class ScannerFacade {
     private VulnerabilitiesRepository repo;
     private static ScannerFacade instance; //Singleton instance
 
-    private ScannerFacade() throws IOException {
+    private ScannerFacade() throws IOException, JSONException {
         this.repo = new VulnerabilitiesRepositoryLoader().load();
     }
 
@@ -31,7 +32,7 @@ public class ScannerFacade {
      * @return Will always return the same instance
      * @throws IOException Unable to load the repository
      */
-    public static ScannerFacade getInstance() throws IOException {
+    public static ScannerFacade getInstance() throws IOException, JSONException {
         if(instance == null) {
             instance = new ScannerFacade();
         }

--- a/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoader.java
+++ b/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoader.java
@@ -7,17 +7,15 @@ import com.h3xstream.retirejs.util.RegexUtil;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.util.*;
+import org.json.JSONException;
 
 public class VulnerabilitiesRepositoryLoader {
 
@@ -32,11 +30,11 @@ public class VulnerabilitiesRepositoryLoader {
      */
     public static final String REPO_URL = "https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json";
 
-    public VulnerabilitiesRepository load(String url) throws IOException {
+    public VulnerabilitiesRepository load(String url) throws IOException, JSONException {
         return load(url, new DefaultDownloader());
     }
 
-    public VulnerabilitiesRepository load(String url, Downloader dl) throws IOException {
+    public VulnerabilitiesRepository load(String url, Downloader dl) throws IOException, JSONException {
         if (url == null || url.length() == 0) {
             throw new IllegalArgumentException("url is null or empty");
         }
@@ -98,18 +96,19 @@ public class VulnerabilitiesRepositoryLoader {
         return loadFromInputStream(inputStream);
     }
 
-    public VulnerabilitiesRepository load() throws IOException {
+    public VulnerabilitiesRepository load() throws IOException, JSONException {
         return load(REPO_URL);
     }
 
-    public VulnerabilitiesRepository loadFromInputStream(InputStream in) throws IOException {
+    public VulnerabilitiesRepository loadFromInputStream(InputStream in) throws IOException, JSONException {
         JSONObject rootJson = new JSONObject(convertStreamToString(in));
 
 
         VulnerabilitiesRepository repo = new VulnerabilitiesRepository();
 
         int nbLoaded = 0;
-        Iterator it = rootJson.keySet().iterator(); //Iterate on each library jquery, YUI, prototypejs, ...
+
+        Iterator it = rootJson.keys(); //Iterate on each library jquery, YUI, prototypejs, ...
         while (it.hasNext()) {
             String key = (String) it.next();
             JSONObject libJson = rootJson.getJSONObject(key);
@@ -160,7 +159,7 @@ public class VulnerabilitiesRepositoryLoader {
 
     ///Convertion utility methods
 
-    public List<String> objToStringList(Object obj, boolean replaceVersionWildcard) {
+    public List<String> objToStringList(Object obj, boolean replaceVersionWildcard) throws JSONException {
         JSONArray array = (JSONArray) obj;
         List<String> strArray = new ArrayList<String>(array.length());
         for (int i = 0; i < array.length(); i++) { //Build Vulnerabilities list
@@ -174,11 +173,11 @@ public class VulnerabilitiesRepositoryLoader {
         return strArray;
     }
 
-    public Map<String, String> objToStringMap(Object obj) {
+    public Map<String, String> objToStringMap(Object obj) throws JSONException {
         Map<String, String> finalMap = new HashMap<String, String>();
 
         JSONObject jsonObj = (JSONObject) obj;
-        Iterator it = jsonObj.keySet().iterator();
+        Iterator it = jsonObj.keys();
         while (it.hasNext()) {
             String key = (String) it.next();
 
@@ -187,11 +186,11 @@ public class VulnerabilitiesRepositoryLoader {
         return finalMap;
     }
 
-    public Map<String, List<String>> objToStringMapMultiValues(Object obj) {
+    public Map<String, List<String>> objToStringMapMultiValues(Object obj) throws JSONException {
         Map<String, List<String>> finalMap = new HashMap<String, List<String>>();
 
         JSONObject jsonObj = (JSONObject) obj;
-        Iterator it = jsonObj.keySet().iterator();
+        Iterator it = jsonObj.keys();
         while (it.hasNext()) {
             String key = (String) it.next();
 

--- a/retirejs-core/src/main/resources/retirejs_repository.json
+++ b/retirejs-core/src/main/resources/retirejs_repository.json
@@ -48,7 +48,7 @@
 				"identifiers": {
 					"issue" : "2432",
 					"summary": "3rd party CORS request may execute",
-				        "CVE": [ "CVE-2015-9251" ]
+					"CVE": [ "CVE-2015-9251" ]
 				},
 				"severity": "medium",
 				"info" : [ "https://github.com/jquery/jquery/issues/2432", "http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/", "https://nvd.nist.gov/vuln/detail/CVE-2015-9251", "http://research.insecurelabs.org/jquery/test/" ]
@@ -59,7 +59,7 @@
 				"identifiers": {
 					"issue" : "2432",
 					"summary": "3rd party CORS request may execute",
-				        "CVE": [ "CVE-2015-9251" ]
+					"CVE": [ "CVE-2015-9251" ]
 				},
 				"severity": "medium",
 				"info" : [ "https://github.com/jquery/jquery/issues/2432", "http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/", "https://nvd.nist.gov/vuln/detail/CVE-2015-9251", "http://research.insecurelabs.org/jquery/test/" ]
@@ -103,25 +103,43 @@
 					"CVE" : [ "CVE-2019-11358" ],
 					"summary": "jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution"
 				},
-				"severity" : "low",
+				"severity" : "medium",
 				"info" : [ "https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/", "https://nvd.nist.gov/vuln/detail/CVE-2019-11358", "https://github.com/jquery/jquery/commit/753d591aea698e57d6db58c9f722cd0808619b1b" ]
+			},
+			{
+				"below" : "3.5.0",
+				"identifiers": {
+					"CVE": [ "CVE-2020-11022" ],
+					"summary": "Regex in its jQuery.htmlPrefilter sometimes may introduce XSS"
+				},
+				"severity" : "medium",
+				"info" : [ "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/" ]
+			},
+			{
+				"below" : "3.5.0",
+				"identifiers": {
+					"CVE": [ "CVE-2020-11023" ],
+					"summary": "Regex in its jQuery.htmlPrefilter sometimes may introduce XSS"
+				},
+				"severity" : "medium",
+				"info" : [ "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/" ]
 			}
 		],
 		"extractors" : {
 			"func"    		: [
-								"(jQuery || $ || $jq || $j).fn.jquery",
-								"require('jquery').fn.jquery"
+				"(window.jQuery || window.$ || window.$jq || window.$j).fn.jquery",
+				"require('jquery').fn.jquery"
 			],
 			"uri"			: [ "/(§§version§§)/jquery(\\.min)?\\.js" ],
 			"filename"		: [ "jquery-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [
-								"/\\*!? jQuery v(§§version§§)", "\\* jQuery JavaScript Library v(§§version§§)",
-								"\\* jQuery (§§version§§) - New Wave Javascript", "// \\$Id: jquery.js,v (§§version§§)",
-								"/\\*! jQuery v(§§version§§)",
-                "[^a-z]f=\"(§§version§§)\",.*[^a-z]jquery:f,",
-                "[^a-z]m=\"(§§version§§)\",.*[^a-z]jquery:m,",
-                "[^a-z.]jquery:[ ]?\"(§§version§§)\"",
-                "\\$\\.documentElement,Q=e.jQuery,Z=e\\.\\$,ee=\\{\\},te=\\[\\],ne=\"(§§version§§)\""
+				"/\\*!? jQuery v(§§version§§)", "\\* jQuery JavaScript Library v(§§version§§)",
+				"\\* jQuery (§§version§§) - New Wave Javascript", "// \\$Id: jquery.js,v (§§version§§)",
+				"/\\*! jQuery v(§§version§§)",
+				"[^a-z]f=\"(§§version§§)\",.*[^a-z]jquery:f,",
+				"[^a-z]m=\"(§§version§§)\",.*[^a-z]jquery:m,",
+				"[^a-z.]jquery:[ ]?\"(§§version§§)\"",
+				"\\$\\.documentElement,Q=e.jQuery,Z=e\\.\\$,ee=\\{\\},te=\\[\\],ne=\"(§§version§§)\""
 			],
 			"filecontentreplace" : [
 				"/var [a-z]=[a-z]\\.document,([a-z])=\"(§§version§§)\",([a-z])=.{130,160};\\3\\.fn=\\3\\.prototype=\\{jquery:\\1/$2/"
@@ -244,7 +262,7 @@
 			},
 			{
 				"below" : "1.12.0",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {
 					"CVE": [ "CVE-2016-7103" ],
 					"bug": "281",
@@ -284,11 +302,11 @@
 			{
 				"atOrAbove": "1.9.2",
 				"below" : "1.10.0",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {
 					"CVE" : [ "CVE-2012-6662" ],
 					"bug": "8859",
-					"summary": "Autocomplete cross-site scripting vulnerability"
+					"summary": "Cross-site scripting (XSS) vulnerability in the default content option in jquery.ui.tooltip"
 				},
 				"info" : [ "http://bugs.jqueryui.com/ticket/8859", "https://nvd.nist.gov/vuln/detail/CVE-2012-6662" ]
 			}
@@ -308,7 +326,7 @@
 		"vulnerabilities" : [
 			{
 				"below" : "3.1.5",
-				"severity" : "high",
+				"severity" : "medium",
 				"identifiers" : { "CVE" : [ "CVE-2013-6837" ] },
 				"info" : [ "https://nvd.nist.gov/vuln/detail/CVE-2013-6837" ]
 			},
@@ -333,7 +351,7 @@
 		"vulnerabilities" : [
 			{
 				"below" : "2.3.1",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {
 					"CVE": [ "CVE-2013-2023" ],
 					"release" : "2.3.1",
@@ -342,7 +360,7 @@
 			},
 			{
 				"below" : "2.3.23",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {
 					"CVE": [ "CVE-2013-2022" ],
 					"release": "2.3.23",
@@ -352,7 +370,7 @@
 			},
 			{
 				"below" : "2.2.20",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {
 					"CVE": [ "CVE-2013-1942" ],
 					"release": "2.2.20",
@@ -451,14 +469,49 @@
 				"identifiers" : { "summary" : "FIXED so links with xlink:href attributes are filtered correctly to prevent XSS." },
 				"info" : [ "https://www.tinymce.com/docs/changelog/" ]
 
+			},
+			{
+				"below" : "5.1.4",
+				"atOrAbove" : "5.0.0",
+				"severity" : "medium",
+				"identifiers" : {
+					"summary" : "The vulnerability allowed arbitrary JavaScript execution when inserting a specially crafted piece of content into the editor via the clipboard or APIs",
+					"githubID" : "GHSA-27gm-ghr9-4v95"
+				},
+				"info" : [ "https://github.com/tinymce/tinymce/security/advisories/GHSA-27gm-ghr9-4v95" ]
+			},
+			{
+				"below" : "5.1.6",
+				"severity" : "medium",
+				"identifiers" : {
+					"summary" : "CDATA parsing and sanitization has been improved to address a cross-site scripting (XSS) vulnerability."
+				},
+				"info" : [ "https://www.tiny.cloud/docs/release-notes/release-notes516/" ]
+			},
+			{
+				"below" : "5.2.2",
+				"severity" : "low",
+				"identifiers" : {
+					"summary" : "media embed content not processing safely in some cases."
+				},
+				"info" : [ "https://www.tiny.cloud/docs/release-notes/release-notes522/" ]
+			},
+			{
+				"below" : "5.4.0",
+				"severity" : "low",
+				"identifiers" : {
+					"summary" : "content in an iframe element parsing as DOM elements instead of text content."
+				},
+				"info" : [ "https://www.tiny.cloud/docs/release-notes/release-notes54/" ]
 			}
+
 		],
 		"extractors" : {
 			"filecontent"	     : [ "// (§§version§§) \\([0-9\\-]+\\)[\n\r]+.{0,1200}l=.tinymce/geom/Rect." ],
 			"filecontentreplace" : [
-										"/tinyMCEPreInit.*majorVersion:.([0-9]+).,minorVersion:.([0-9.]+)./$1.$2/",
-										"/majorVersion:.([0-9]+).,minorVersion:.([0-9.]+).,.*tinyMCEPreInit/$1.$2/"
-								   ],
+				"/tinyMCEPreInit.*majorVersion:.([0-9]+).,minorVersion:.([0-9.]+)./$1.$2/",
+				"/majorVersion:.([0-9]+).,minorVersion:.([0-9.]+).,.*tinyMCEPreInit/$1.$2/"
+			],
 			"func" 				 : [ "tinyMCE.majorVersion + '.'+ tinyMCE.minorVersion" ]
 		}
 	},
@@ -469,49 +522,49 @@
 			{
 				"atOrAbove" : "3.5.0" ,
 				"below" : "3.9.2",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2013-4942" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2013-4942/" ]
 			},
 			{
 				"atOrAbove" : "3.2.0" ,
 				"below" : "3.9.2",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2013-4941" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2013-4941/" ]
 			},
 			{
 				"atOrAbove" : "3.0.0",
 				"below" : "3.10.3",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2013-4940" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2013-4940/" ]
 			},
 			{
 				"atOrAbove" : "3.0.0" ,
 				"below" : "3.9.2",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2013-4939" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2013-4939/" ]
 			},
 			{
 				"atOrAbove" : "2.8.0" ,
 				"below" : "2.9.1",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2012-5883" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2012-5883/" ]
 			},
 			{
 				"atOrAbove" : "2.5.0" ,
 				"below" : "2.9.1",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2012-5882" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2012-5882/" ]
 			},
 			{
 				"atOrAbove" : "2.4.0" ,
 				"below" : "2.9.1",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2012-5881" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2012-5881/" ]
 			},
@@ -524,21 +577,21 @@
 			{
 				"atOrAbove" : "2.8.0" ,
 				"below" : "2.8.2",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2010-4209" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2010-4209/" ]
 			},
 			{
 				"atOrAbove" : "2.5.0" ,
 				"below" : "2.8.2",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2010-4208" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2010-4208/" ]
 			},
 			{
 				"atOrAbove" : "2.4.0" ,
 				"below" : "2.8.2",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2010-4207" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2010-4207/" ]
 			}
@@ -570,7 +623,7 @@
 			"uri"			: [ "/(§§version§§)/prototype(\\.min)?\\.js" ],
 			"filename"		: [ "prototype-(§§version§§)(.min)?\\.js" ],
 			"filecontent"	: [ "Prototype JavaScript framework, version (§§version§§)",
-								"Prototype[ ]?=[ ]?\\{[ \r\n\t]*Version:[ ]?(?:'|\")(§§version§§)(?:'|\")" ],
+				"Prototype[ ]?=[ ]?\\{[ \r\n\t]*Version:[ ]?(?:'|\")(§§version§§)(?:'|\")" ],
 			"hashes"		: {}
 		}
 	},
@@ -620,7 +673,7 @@
 			},
 			{
 				"below" : "1.5.0",
-				"severity": "medium",
+				"severity": "low",
 				"identifiers": {
 					"CVE": [ "CVE-2014-0046" ],
 					"summary": "ember-routing-auto-location can be forced to redirect to another domain"
@@ -630,48 +683,48 @@
 			{
 				"atOrAbove" : "1.3.0-*",
 				"below" : "1.3.2",
-				"severity": "medium",
+				"severity": "low",
 				"identifiers": {"CVE": [ "CVE-2014-0046" ] },
 				"info" : [ "https://groups.google.com/forum/#!topic/ember-security/1h6FRgr8lXQ" ]
 			},
 			{
 				"atOrAbove" : "1.2.0-*",
 				"below" : "1.2.2",
-				"severity": "medium",
+				"severity": "low",
 				"identifiers": {"CVE": [ "CVE-2014-0046" ] },
 				"info" : [ "https://groups.google.com/forum/#!topic/ember-security/1h6FRgr8lXQ" ] },
 			{
 				"atOrAbove" : "1.4.0-*",
 				"below" : "1.4.0-beta.2",
-				"severity": "high",
+				"severity": "low",
 				"identifiers": {"CVE": ["CVE-2014-0013", "CVE-2014-0014"]},
 				"info" : [ "https://groups.google.com/forum/#!topic/ember-security/2kpXXCxISS4", "https://groups.google.com/forum/#!topic/ember-security/PSE4RzTi6l4" ]
 			},
 			{
 				"atOrAbove" : "1.3.0-*",
 				"below" : "1.3.1",
-				"severity": "high",
+				"severity": "low",
 				"identifiers": {"CVE": ["CVE-2014-0013", "CVE-2014-0014"]},
 				"info" : [ "https://groups.google.com/forum/#!topic/ember-security/2kpXXCxISS4", "https://groups.google.com/forum/#!topic/ember-security/PSE4RzTi6l4" ]
 			},
 			{
 				"atOrAbove" : "1.2.0-*",
 				"below" : "1.2.1",
-				"severity": "high",
+				"severity": "low",
 				"identifiers": {"CVE": ["CVE-2014-0013", "CVE-2014-0014"]},
 				"info" : [ "https://groups.google.com/forum/#!topic/ember-security/2kpXXCxISS4", "https://groups.google.com/forum/#!topic/ember-security/PSE4RzTi6l4" ]
 			},
 			{
 				"atOrAbove" : "1.1.0-*",
 				"below" : "1.1.3",
-				"severity": "high",
+				"severity": "low",
 				"identifiers": {"CVE": ["CVE-2014-0013", "CVE-2014-0014"]},
 				"info" : [ "https://groups.google.com/forum/#!topic/ember-security/2kpXXCxISS4", "https://groups.google.com/forum/#!topic/ember-security/PSE4RzTi6l4" ]
 			},
 			{
 				"atOrAbove" : "1.0.0-*",
 				"below" : "1.0.1",
-				"severity": "high",
+				"severity": "low",
 				"identifiers": {"CVE": ["CVE-2014-0013", "CVE-2014-0014"]},
 				"info" : [ "https://groups.google.com/forum/#!topic/ember-security/2kpXXCxISS4", "https://groups.google.com/forum/#!topic/ember-security/PSE4RzTi6l4" ]
 			},
@@ -826,12 +879,53 @@
 				"identifiers": { "PR" : "307" },
 				"info" : [ "https://github.com/dojo/dojo/pull/307" , "https://dojotoolkit.org/blog/dojo-1-14-released"]
 			},
-      {
-        "below" : "1.14",
-        "severity": "medium",
-        "identifiers": { "CVE": ["CVE-2018-15494"] },
-        "info" : [ "https://dojotoolkit.org/blog/dojo-1-14-released" ]
-      }
+			{
+				"below" : "1.14",
+				"severity": "high",
+				"identifiers": { "CVE": ["CVE-2018-15494"] },
+				"info" : [ "https://dojotoolkit.org/blog/dojo-1-14-released" ]
+			},
+			{
+				"below" : "1.11.10",
+				"severity": "medium",
+				"identifiers": { "CVE": ["CVE-2020-5258"] },
+				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+			},
+			{
+				"below" : "1.12.8",
+				"atOrAbove" : "1.12.0",
+				"severity": "medium",
+				"identifiers": { "CVE": ["CVE-2020-5258"] },
+				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+			},
+			{
+				"below" : "1.13.7",
+				"atOrAbove" : "1.13.0",
+				"severity": "medium",
+				"identifiers": { "CVE": ["CVE-2020-5258"] },
+				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+			},
+			{
+				"below" : "1.14.6",
+				"atOrAbove" : "1.14.0",
+				"severity": "medium",
+				"identifiers": { "CVE": ["CVE-2020-5258"] },
+				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+			},
+			{
+				"below" : "1.15.3",
+				"atOrAbove" : "1.15.0",
+				"severity": "medium",
+				"identifiers": { "CVE": ["CVE-2020-5258"] },
+				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+			},
+			{
+				"below" : "1.16.2",
+				"atOrAbove" : "1.16.0",
+				"severity": "medium",
+				"identifiers": { "CVE": ["CVE-2020-5258"] },
+				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+			}
 		],
 		"extractors" : {
 			"func"				 : [ "dojo.version.toString()" ],
@@ -855,6 +949,32 @@
 	"angularjs" : {
 		"bowername": [ "angularjs", "angular.js" ],
 		"vulnerabilities" : [
+			{
+				"below" : "1.8.0",
+				"severity": "medium",
+				"identifiers": {
+					"summary": "XSS may be triggered in AngularJS applications that sanitize user-controlled HTML snippets before passing them to JQLite methods like JQLite.prepend, JQLite.after, JQLite.append, JQLite.replaceWith, JQLite.append, new JQLite and angular.element.",
+					"CVE": [ "CVE-2020-7676" ]
+				},
+				"info" : [ "https://github.com/advisories/GHSA-5cp4-xmrw-59wf" ]
+			},
+			{
+				"below" : "1.8.0",
+				"severity": "low",
+				"identifiers": {
+					"summary": "angular.js prior to 1.8.0 allows cross site scripting. The regex-based input HTML replacement may turn sanitized code into unsanitized one.",
+					"CVE": [ "CVE-2020-7676" ]
+				},
+				"info" : [ "https://nvd.nist.gov/vuln/detail/CVE-2020-7676" ]
+			},
+			{
+				"below" : "1.7.9",
+				"severity": "medium",
+				"identifiers": {
+					"summary": "Prototype pollution"
+				},
+				"info" : [ "https://github.com/angular/angular.js/commit/726f49dcf6c23106ddaf5cfd5e2e592841db743a", "https://github.com/angular/angular.js/blob/master/CHANGELOG.md#179-pollution-eradication-2019-11-19" ]
+			},
 			{
 				"atOrAbove" : "1.5.0",
 				"below" : "1.6.9",
@@ -966,13 +1086,13 @@
 			"uri"			: [ "/(§§version§§)/mustache(\\.min)?\\.js" ],
 			"filename"		: [ "mustache(?:js)?-(§§version§§)(.min)?\\.js" ],
 			"filecontent"	: [ "name:\"mustache.js\",version:\"(§§version§§)\"",
-								"[^a-z]mustache.version[ ]?=[ ]?(?:'|\")(§§version§§)(?:'|\")",
-								"exports.name[ ]?=[ ]?\"mustache.js\";[\n ]*exports.version[ ]?=[ ]?(?:'|\")(§§version§§)(?:'|\");"
-								],
+				"[^a-z]mustache.version[ ]?=[ ]?(?:'|\")(§§version§§)(?:'|\")",
+				"exports.name[ ]?=[ ]?\"mustache.js\";[\n ]*exports.version[ ]?=[ ]?(?:'|\")(§§version§§)(?:'|\");"
+			],
 			"hashes"		: {}
 		}
 	},
-	"handlebars.js" : {
+	"handlebars" : {
 		"bowername": [ "handlebars", "handlebars.js" ],
 		"vulnerabilities" : [
 			{
@@ -1028,6 +1148,26 @@
 					"https://github.com/wycats/handlebars.js/issues/1495",
 					"https://github.com/wycats/handlebars.js/commit/cd38583216dce3252831916323202749431c773e"
 				]
+			},
+			{
+				"below" : "4.3.0",
+				"severity": "low",
+				"identifiers": {
+					"summary": "Disallow calling helperMissing and blockHelperMissing directly"
+				},
+				"info" : [
+					"https://github.com/wycats/handlebars.js/blob/master/release-notes.md#v430---september-24th-2019"
+				]
+			},
+			{
+				"below" : "4.5.3",
+				"severity": "medium",
+				"identifiers": {
+					"summary": "Prototype pollution"
+				},
+				"info" : [
+					"https://github.com/wycats/handlebars.js/blob/master/release-notes.md#v453---november-18th-2019"
+				]
 			}
 		],
 		"extractors" : {
@@ -1037,7 +1177,7 @@
 			"filecontent"	: [
 				"Handlebars.VERSION = \"(§§version§§)\";", "Handlebars=\\{VERSION:(?:'|\")(§§version§§)(?:'|\")",
 				"this.Handlebars=\\{\\};[\n\r \t]+\\(function\\([a-z]\\)\\{[a-z].VERSION=(?:'|\")(§§version§§)(?:'|\")",
-				"/\\*![\n\r \t]+handlebars v(§§version§§)"
+				"/\\*+![\\s]+(?:@license)?[\\s]+handlebars v(§§version§§)"
 			],
 			"hashes"		: {}
 		}
@@ -1046,13 +1186,13 @@
 		"vulnerabilities" : [
 			{
 				"below" : "2.4.18",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2013-5212" ] },
 				"info" : [ "http://blog.kotowicz.net/2013/09/exploiting-easyxdm-part-1-not-usual.html", "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-5212" ]
 			},
 			{
 				"below" : "2.4.19",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2014-1403" ] },
 				"info" : [ "http://blog.kotowicz.net/2014/01/xssing-with-shakespeare-name-calling.html", "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1403" ]
 			}
@@ -1061,7 +1201,7 @@
 			"uri"			: [ "/(?:easyXDM-)?(§§version§§)/easyXDM(\\.min)?\\.js" ],
 			"filename"		: [ "easyXDM-(§§version§§)(.min)?\\.js" ],
 			"filecontent"	: [ " \\* easyXDM\n \\* http://easyxdm.net/(?:\r|\n|.)+version:\"(§§version§§)\"",
-								"@class easyXDM(?:.|\r|\n)+@version (§§version§§)(\r|\n)" ],
+				"@class easyXDM(?:.|\r|\n)+@version (§§version§§)(\r|\n)" ],
 			"hashes"		: { "cf266e3bc2da372c4f0d6b2bd87bcbaa24d5a643" : "2.4.6"}
 		}
 	},
@@ -1071,13 +1211,13 @@
 		"vulnerabilities" : [
 			{
 				"below" : "1.5.4",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2012-2401" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2012-2401/" ]
 			},
 			{
 				"below" : "1.5.5",
-				"severity": "high",
+				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2013-0237" ] },
 				"info" : [ "http://www.cvedetails.com/cve/CVE-2013-0237/" ]
 			},
@@ -1093,8 +1233,8 @@
 			"uri"			: [ "/(§§version§§)/plupload(\\.min)?\\.js" ],
 			"filename"		: [ "plupload-(§§version§§)(.min)?\\.js" ],
 			"filecontent"	: [ "\\* Plupload - multi-runtime File Uploader(?:\r|\n)+ \\* v(§§version§§)",
-								"var g=\\{VERSION:\"(§§version§§)\",.*;window.plupload=g\\}"
-								],
+				"var g=\\{VERSION:\"(§§version§§)\",.*;window.plupload=g\\}"
+			],
 			"hashes"		: {}
 		}
 	},
@@ -1125,6 +1265,48 @@
 				"severity": "low",
 				"identifiers": { "summary": "safari UXSS" },
 				"info" : [ "https://github.com/cure53/DOMPurify/releases/tag/0.9.0" ]
+			},
+			{
+				"below" : "2.0.16",
+				"severity": "low",
+				"identifiers": { "summary": "Fixed an mXSS-based bypass caused by nested forms inside MathML" },
+				"info" : [ "https://github.com/cure53/DOMPurify/releases" ]
+			},
+			{
+				"below" : "2.0.17",
+				"severity": "low",
+				"identifiers": { "summary": "Fixed another bypass causing mXSS by using MathML" },
+				"info" : [ "https://github.com/cure53/DOMPurify/releases" ]
+			},
+			{
+				"below" : "2.1.1",
+				"severity": "low",
+				"identifiers": { "summary": "Fixed several possible mXSS patterns, thanks @hackvertor" },
+				"info" : [ "https://github.com/cure53/DOMPurify/releases" ]
+			},
+			{
+				"below" : "2.2.0",
+				"severity": "low",
+				"identifiers": { "summary": "Fix a possible XSS in Chrome that is hidden behind #enable-experimental-web-platform-features" },
+				"info" : [ "https://github.com/cure53/DOMPurify/releases" ]
+			},
+			{
+				"below" : "2.2.2",
+				"severity": "low",
+				"identifiers": { "summary": "Fixed an mXSS bypass dropped on us publicly via" },
+				"info" : [ "https://github.com/cure53/DOMPurify/releases" ]
+			},
+			{
+				"below" : "2.2.3",
+				"severity": "low",
+				"identifiers": { "summary": "Fixed an mXSS issue reported" },
+				"info" : [ "https://github.com/cure53/DOMPurify/releases" ]
+			},
+			{
+				"below" : "2.2.4",
+				"severity": "low",
+				"identifiers": { "summary": "Fixed a new MathML-based bypass submitted by PewGrand. Fixed a new SVG-related bypass submitted by SecurityMB" },
+				"info" : [ "https://github.com/cure53/DOMPurify/releases" ]
 			}
 		],
 		"extractors" : {
@@ -1166,7 +1348,7 @@
 			},
 			{
 				"atOrAbove" : "16.0.0", "below" : "16.0.1",
-				"severity" : "low",
+				"severity" : "medium",
 				"identifiers" : {
 					"CVE": [ "CVE-2018-6341" ],
 					"summary":"potential XSS vulnerability when the attacker controls an attribute name"
@@ -1175,7 +1357,7 @@
 			},
 			{
 				"atOrAbove" : "16.1.0", "below" : "16.1.2",
-				"severity" : "low",
+				"severity" : "medium",
 				"identifiers" : {
 					"CVE": [ "CVE-2018-6341" ],
 					"summary":"potential XSS vulnerability when the attacker controls an attribute name"
@@ -1184,7 +1366,7 @@
 			},
 			{
 				"atOrAbove" : "16.2.0", "below" : "16.2.1",
-				"severity" : "low",
+				"severity" : "medium",
 				"identifiers" : {
 					"CVE": [ "CVE-2018-6341" ],
 					"summary":"potential XSS vulnerability when the attacker controls an attribute name"
@@ -1193,7 +1375,7 @@
 			},
 			{
 				"atOrAbove" : "16.3.0", "below" : "16.3.3",
-				"severity" : "low",
+				"severity" : "medium",
 				"identifiers" : {
 					"CVE": [ "CVE-2018-6341" ],
 					"summary":"potential XSS vulnerability when the attacker controls an attribute name"
@@ -1202,7 +1384,7 @@
 			},
 			{
 				"atOrAbove" : "16.4.0", "below" : "16.4.2",
-				"severity" : "low",
+				"severity" : "medium",
 				"identifiers" : {
 					"CVE": [ "CVE-2018-6341" ],
 					"summary":"potential XSS vulnerability when the attacker controls an attribute name"
@@ -1296,7 +1478,7 @@
 					"summary": "XSS in data-template, data-content and data-title properties of tooltip/popover",
 					"CVE" : ["CVE-2019-8331"]
 				},
-				"severity" : "high",
+				"severity" : "medium",
 				"info" : [ "https://github.com/twbs/bootstrap/issues/28236" ]
 			},
 			{
@@ -1306,7 +1488,7 @@
 					"summary": "XSS in data-template, data-content and data-title properties of tooltip/popover",
 					"CVE" : ["CVE-2019-8331"]
 				},
-				"severity" : "high",
+				"severity" : "medium",
 				"info" : [ "https://github.com/twbs/bootstrap/issues/28236" ]
 			},
 			{
@@ -1385,9 +1567,10 @@
 			"uri"			: [ "/(§§version§§)/bootstrap(\\.min)?\\.js", "/(§§version§§)/js/bootstrap(\\.min)?\\.js" ],
 			"filename"		: [ "bootstrap-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [
-								"/\\*!? Bootstrap v(§§version§§)",
-								"\\* Bootstrap v(§§version§§)",
-								"/\\*! Bootstrap v(§§version§§)"
+				"/\\*!? Bootstrap v(§§version§§)",
+				"\\* Bootstrap v(§§version§§)",
+				"/\\*! Bootstrap v(§§version§§)",
+				"this\\.close\\)};.\\.VERSION=\"(§§version§§)\"(?:,.\\.TRANSITION_DURATION=150)?,.\\.prototype\\.close"
 			],
 			"hashes"		: {}
 		}
@@ -1447,14 +1630,40 @@
 					"https://ckeditor.com/blog/CKEditor-4.11-with-emoji-dropdown-and-auto-link-on-typing-released/",
 					"https://snyk.io/vuln/SNYK-JS-CKEDITOR-72618"
 				]
+			},
+			{
+				"below" : "4.15.1",
+				"identifiers" : {
+					"summary" : "XSS-type attack inside CKEditor 4 by persuading a victim to paste a specially crafted HTML code into the Color Button dialog"
+				},
+				"severity" : "medium",
+				"info" : [
+					"https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md#ckeditor-4151"
+				]
+			},
+			{
+				"below" : "4.14.0",
+				"identifiers" : {
+					"summary" : "XSS"
+				},
+				"severity" : "low",
+				"info": [ "https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md#ckeditor-414" ]
+			},
+			{
+				"below" : "4.16.0",
+				"identifiers" : {
+					"summary" : "ReDoS vulnerability in Autolink plugin and Advanced Tab for Dialogs plugin"
+				},
+				"severity" : "low",
+				"info": [ "https://ckeditor.com/cke4/release/CKEditor-4.16.0" ]
 			}
 		],
 		"extractors" : {
 			"uri"			: [ "/(§§version§§)/ckeditor(\\.min)?\\.js" ],
 			"filename"		: [ "ckeditor-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [
-								"ckeditor..js.{4,20}=\\{timestamp:\"[^\"]+\",version:\"(§§version§§)",
-								"window.CKEDITOR=function\\(\\)\\{var [a-z]=\\{timestamp:\"[^\"]+\",version:\"(§§version§§)"
+				"ckeditor..js.{4,20}=\\{timestamp:\"[^\"]+\",version:\"(§§version§§)",
+				"window.CKEDITOR=function\\(\\)\\{var [a-z]=\\{timestamp:\"[^\"]+\",version:\"(§§version§§)"
 			],
 			"hashes"		: {},
 			"func"			: [ "CKEDITOR.version" ]
@@ -1464,6 +1673,14 @@
 
 	"vue" : {
 		"vulnerabilities" : [
+			{
+				"below" : "2.6.11",
+				"severity" : "medium",
+				"identifiers" : {
+					"summary" : "Bump vue-server-renderer's dependency of serialize-javascript to 2.1.2"
+				},
+				"info" : [ "https://github.com/vuejs/vue/releases/tag/v2.6.11" ]
+			},
 			{
 				"below" : "2.5.17",
 				"severity" : "medium",
@@ -1487,7 +1704,7 @@
 			],
 			"filename"		: [ "vue-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [
-				"/\\*!\\n * Vue.js v(§§version§§)",
+				"/\\*!\\n \\* Vue.js v(§§version§§)",
 				"Vue.version = '(§§version§§)';",
 				"'(§§version§§)'[^\\n]{0,8000}Vue compiler"
 			],
@@ -1500,7 +1717,7 @@
 			{
 				"below"       : "6.6.0",
 				"atOrAbove"   : "4.0.0",
-				"severity"    : "high",
+				"severity"    : "medium",
 				"identifiers" : {
 					"CVE"     : [
 						"CVE-2018-8046"
@@ -1530,7 +1747,7 @@
 			{
 				"below"       : "4.0.0",
 				"atOrAbove"   : "3.0.0",
-				"severity"    : "high",
+				"severity"    : "medium",
 				"identifiers" : {
 					"CVE"     : [
 						"CVE-2010-4207",

--- a/retirejs-core/src/main/resources/retirejs_repository.json
+++ b/retirejs-core/src/main/resources/retirejs_repository.json
@@ -48,7 +48,7 @@
 				"identifiers": {
 					"issue" : "2432",
 					"summary": "3rd party CORS request may execute",
-					"CVE": [ "CVE-2015-9251" ]
+				        "CVE": [ "CVE-2015-9251" ]
 				},
 				"severity": "medium",
 				"info" : [ "https://github.com/jquery/jquery/issues/2432", "http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/", "https://nvd.nist.gov/vuln/detail/CVE-2015-9251", "http://research.insecurelabs.org/jquery/test/" ]
@@ -59,7 +59,7 @@
 				"identifiers": {
 					"issue" : "2432",
 					"summary": "3rd party CORS request may execute",
-					"CVE": [ "CVE-2015-9251" ]
+				        "CVE": [ "CVE-2015-9251" ]
 				},
 				"severity": "medium",
 				"info" : [ "https://github.com/jquery/jquery/issues/2432", "http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/", "https://nvd.nist.gov/vuln/detail/CVE-2015-9251", "http://research.insecurelabs.org/jquery/test/" ]
@@ -127,19 +127,19 @@
 		],
 		"extractors" : {
 			"func"    		: [
-				"(window.jQuery || window.$ || window.$jq || window.$j).fn.jquery",
-				"require('jquery').fn.jquery"
+								"(window.jQuery || window.$ || window.$jq || window.$j).fn.jquery",
+								"require('jquery').fn.jquery"
 			],
 			"uri"			: [ "/(§§version§§)/jquery(\\.min)?\\.js" ],
 			"filename"		: [ "jquery-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [
-				"/\\*!? jQuery v(§§version§§)", "\\* jQuery JavaScript Library v(§§version§§)",
-				"\\* jQuery (§§version§§) - New Wave Javascript", "// \\$Id: jquery.js,v (§§version§§)",
-				"/\\*! jQuery v(§§version§§)",
-				"[^a-z]f=\"(§§version§§)\",.*[^a-z]jquery:f,",
-				"[^a-z]m=\"(§§version§§)\",.*[^a-z]jquery:m,",
-				"[^a-z.]jquery:[ ]?\"(§§version§§)\"",
-				"\\$\\.documentElement,Q=e.jQuery,Z=e\\.\\$,ee=\\{\\},te=\\[\\],ne=\"(§§version§§)\""
+								"/\\*!? jQuery v(§§version§§)", "\\* jQuery JavaScript Library v(§§version§§)",
+								"\\* jQuery (§§version§§) - New Wave Javascript", "// \\$Id: jquery.js,v (§§version§§)",
+								"/\\*! jQuery v(§§version§§)",
+                "[^a-z]f=\"(§§version§§)\",.*[^a-z]jquery:f,",
+                "[^a-z]m=\"(§§version§§)\",.*[^a-z]jquery:m,",
+                "[^a-z.]jquery:[ ]?\"(§§version§§)\"",
+                "\\$\\.documentElement,Q=e.jQuery,Z=e\\.\\$,ee=\\{\\},te=\\[\\],ne=\"(§§version§§)\""
 			],
 			"filecontentreplace" : [
 				"/var [a-z]=[a-z]\\.document,([a-z])=\"(§§version§§)\",([a-z])=.{130,160};\\3\\.fn=\\3\\.prototype=\\{jquery:\\1/$2/"
@@ -340,7 +340,7 @@
 		"extractors" : {
 			"func"    		: [ "jQuery.prettyPhoto.version" ],
 			"filecontent"	: [
-				"/\\*(?:.*[\n\r]+){1,3}.*Class: prettyPhoto(?:.*[\n\r]+){1,3}.*Version: (§§version§§)",
+				"/\\*[\r\n -]+Class: prettyPhoto(?:.*\n){1,3}[ ]*Version: (§§version§§)",
 				"\\.prettyPhoto[ ]?=[ ]?\\{version:[ ]?(?:'|\")(§§version§§)(?:'|\")\\}"
 			],
 			"hashes"		: {}
@@ -382,7 +382,8 @@
 		"extractors" : {
 			"func"    		: [ "new jQuery.jPlayer().version.script" ],
 			"filecontent"	: [
-				"/\\*(?:.*[\n\r]+){1,3}.*jPlayer Plugin for jQuery(?:.*[\n\r]+){1,10}.*Version: (§§version§§)"
+				"/\\*!?[\n *]+jPlayer Plugin for jQuery (?:.*\n){1,10}[ *]+Version: (§§version§§)",
+				"/\\*!? jPlayer (§§version§§) for jQuery"
 			],
 			"hashes"		: {}
 		}
@@ -509,9 +510,9 @@
 		"extractors" : {
 			"filecontent"	     : [ "// (§§version§§) \\([0-9\\-]+\\)[\n\r]+.{0,1200}l=.tinymce/geom/Rect." ],
 			"filecontentreplace" : [
-				"/tinyMCEPreInit.*majorVersion:.([0-9]+).,minorVersion:.([0-9.]+)./$1.$2/",
-				"/majorVersion:.([0-9]+).,minorVersion:.([0-9.]+).,.*tinyMCEPreInit/$1.$2/"
-			],
+										"/tinyMCEPreInit.*majorVersion:.([0-9]+).,minorVersion:.([0-9.]+)./$1.$2/",
+										"/majorVersion:.([0-9]+).,minorVersion:.([0-9.]+).,.*tinyMCEPreInit/$1.$2/"
+								   ],
 			"func" 				 : [ "tinyMCE.majorVersion + '.'+ tinyMCE.minorVersion" ]
 		}
 	},
@@ -623,7 +624,7 @@
 			"uri"			: [ "/(§§version§§)/prototype(\\.min)?\\.js" ],
 			"filename"		: [ "prototype-(§§version§§)(.min)?\\.js" ],
 			"filecontent"	: [ "Prototype JavaScript framework, version (§§version§§)",
-				"Prototype[ ]?=[ ]?\\{[ \r\n\t]*Version:[ ]?(?:'|\")(§§version§§)(?:'|\")" ],
+								"Prototype[ ]?=[ ]?\\{[ \r\n\t]*Version:[ ]?(?:'|\")(§§version§§)(?:'|\")" ],
 			"hashes"		: {}
 		}
 	},
@@ -879,53 +880,53 @@
 				"identifiers": { "PR" : "307" },
 				"info" : [ "https://github.com/dojo/dojo/pull/307" , "https://dojotoolkit.org/blog/dojo-1-14-released"]
 			},
-			{
-				"below" : "1.14",
-				"severity": "high",
-				"identifiers": { "CVE": ["CVE-2018-15494"] },
-				"info" : [ "https://dojotoolkit.org/blog/dojo-1-14-released" ]
-			},
-			{
-				"below" : "1.11.10",
-				"severity": "medium",
-				"identifiers": { "CVE": ["CVE-2020-5258"] },
-				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
-			},
-			{
-				"below" : "1.12.8",
+		    {
+		        "below" : "1.14",
+		        "severity": "high",
+		        "identifiers": { "CVE": ["CVE-2018-15494"] },
+		        "info" : [ "https://dojotoolkit.org/blog/dojo-1-14-released" ]
+		    },
+		    {
+		        "below" : "1.11.10",
+		        "severity": "medium",
+		        "identifiers": { "CVE": ["CVE-2020-5258"] },
+		        "info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+		    },
+		    {
+		        "below" : "1.12.8",
 				"atOrAbove" : "1.12.0",
-				"severity": "medium",
-				"identifiers": { "CVE": ["CVE-2020-5258"] },
-				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
-			},
-			{
-				"below" : "1.13.7",
+		        "severity": "medium",
+		        "identifiers": { "CVE": ["CVE-2020-5258"] },
+		        "info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+		    },
+		    {
+		        "below" : "1.13.7",
 				"atOrAbove" : "1.13.0",
-				"severity": "medium",
-				"identifiers": { "CVE": ["CVE-2020-5258"] },
-				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
-			},
-			{
-				"below" : "1.14.6",
+		        "severity": "medium",
+		        "identifiers": { "CVE": ["CVE-2020-5258"] },
+		        "info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+		    },
+		    {
+		        "below" : "1.14.6",
 				"atOrAbove" : "1.14.0",
-				"severity": "medium",
-				"identifiers": { "CVE": ["CVE-2020-5258"] },
-				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
-			},
-			{
-				"below" : "1.15.3",
+		        "severity": "medium",
+		        "identifiers": { "CVE": ["CVE-2020-5258"] },
+		        "info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+		    },
+		    {
+		        "below" : "1.15.3",
 				"atOrAbove" : "1.15.0",
-				"severity": "medium",
-				"identifiers": { "CVE": ["CVE-2020-5258"] },
-				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
-			},
-			{
-				"below" : "1.16.2",
+		        "severity": "medium",
+		        "identifiers": { "CVE": ["CVE-2020-5258"] },
+		        "info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+		    },
+		    {
+		        "below" : "1.16.2",
 				"atOrAbove" : "1.16.0",
-				"severity": "medium",
-				"identifiers": { "CVE": ["CVE-2020-5258"] },
-				"info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
-			}
+		        "severity": "medium",
+		        "identifiers": { "CVE": ["CVE-2020-5258"] },
+		        "info" : [ "https://github.com/dojo/dojo/security/advisories/GHSA-jxfh-8wgv-vfr2" ]
+		    }
 		],
 		"extractors" : {
 			"func"				 : [ "dojo.version.toString()" ],
@@ -1086,9 +1087,9 @@
 			"uri"			: [ "/(§§version§§)/mustache(\\.min)?\\.js" ],
 			"filename"		: [ "mustache(?:js)?-(§§version§§)(.min)?\\.js" ],
 			"filecontent"	: [ "name:\"mustache.js\",version:\"(§§version§§)\"",
-				"[^a-z]mustache.version[ ]?=[ ]?(?:'|\")(§§version§§)(?:'|\")",
-				"exports.name[ ]?=[ ]?\"mustache.js\";[\n ]*exports.version[ ]?=[ ]?(?:'|\")(§§version§§)(?:'|\");"
-			],
+								"[^a-z]mustache.version[ ]?=[ ]?(?:'|\")(§§version§§)(?:'|\")",
+								"exports.name[ ]?=[ ]?\"mustache.js\";[\n ]*exports.version[ ]?=[ ]?(?:'|\")(§§version§§)(?:'|\");"
+								],
 			"hashes"		: {}
 		}
 	},
@@ -1201,7 +1202,7 @@
 			"uri"			: [ "/(?:easyXDM-)?(§§version§§)/easyXDM(\\.min)?\\.js" ],
 			"filename"		: [ "easyXDM-(§§version§§)(.min)?\\.js" ],
 			"filecontent"	: [ " \\* easyXDM\n \\* http://easyxdm.net/(?:\r|\n|.)+version:\"(§§version§§)\"",
-				"@class easyXDM(?:.|\r|\n)+@version (§§version§§)(\r|\n)" ],
+								"@class easyXDM(?:.|\r|\n)+@version (§§version§§)(\r|\n)" ],
 			"hashes"		: { "cf266e3bc2da372c4f0d6b2bd87bcbaa24d5a643" : "2.4.6"}
 		}
 	},
@@ -1226,6 +1227,19 @@
 				"severity": "medium",
 				"identifiers": {"CVE": [ "CVE-2016-4566" ] },
 				"info" : [ "https://github.com/moxiecode/plupload/releases" ]
+			},
+			{
+				"below" : "2.3.7",
+				"severity": "medium",
+				"identifiers": { "summary": "Fixed security vulnerability by adding die calls to all php files to prevent them from being executed unless modified." },
+				"info" : [ "https://github.com/moxiecode/plupload/releases/tag/v2.3.7" ]
+			},
+			{
+				"below" : "3.1.3",
+				"atOrAbove" : "3.0.0",
+				"severity": "medium",
+				"identifiers": { "summary": "Fixed security vulnerability by adding die calls to all php files to prevent them from being executed unless modified." },
+				"info" : [ "https://github.com/moxiecode/plupload/releases/tag/v3.1.3" ]
 			}
 		],
 		"extractors" : {
@@ -1233,8 +1247,8 @@
 			"uri"			: [ "/(§§version§§)/plupload(\\.min)?\\.js" ],
 			"filename"		: [ "plupload-(§§version§§)(.min)?\\.js" ],
 			"filecontent"	: [ "\\* Plupload - multi-runtime File Uploader(?:\r|\n)+ \\* v(§§version§§)",
-				"var g=\\{VERSION:\"(§§version§§)\",.*;window.plupload=g\\}"
-			],
+								"var g=\\{VERSION:\"(§§version§§)\",.*;window.plupload=g\\}"
+								],
 			"hashes"		: {}
 		}
 	},
@@ -1567,10 +1581,10 @@
 			"uri"			: [ "/(§§version§§)/bootstrap(\\.min)?\\.js", "/(§§version§§)/js/bootstrap(\\.min)?\\.js" ],
 			"filename"		: [ "bootstrap-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [
-				"/\\*!? Bootstrap v(§§version§§)",
-				"\\* Bootstrap v(§§version§§)",
-				"/\\*! Bootstrap v(§§version§§)",
-				"this\\.close\\)};.\\.VERSION=\"(§§version§§)\"(?:,.\\.TRANSITION_DURATION=150)?,.\\.prototype\\.close"
+								"/\\*!? Bootstrap v(§§version§§)",
+								"\\* Bootstrap v(§§version§§)",
+								"/\\*! Bootstrap v(§§version§§)",
+								"this\\.close\\)};.\\.VERSION=\"(§§version§§)\"(?:,.\\.TRANSITION_DURATION=150)?,.\\.prototype\\.close"
 			],
 			"hashes"		: {}
 		}
@@ -1662,8 +1676,8 @@
 			"uri"			: [ "/(§§version§§)/ckeditor(\\.min)?\\.js" ],
 			"filename"		: [ "ckeditor-(§§version§§)(\\.min)?\\.js" ],
 			"filecontent"	: [
-				"ckeditor..js.{4,20}=\\{timestamp:\"[^\"]+\",version:\"(§§version§§)",
-				"window.CKEDITOR=function\\(\\)\\{var [a-z]=\\{timestamp:\"[^\"]+\",version:\"(§§version§§)"
+								"ckeditor..js.{4,20}=\\{timestamp:\"[^\"]+\",version:\"(§§version§§)",
+								"window.CKEDITOR=function\\(\\)\\{var [a-z]=\\{timestamp:\"[^\"]+\",version:\"(§§version§§)"
 			],
 			"hashes"		: {},
 			"func"			: [ "CKEDITOR.version" ]

--- a/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoaderManualTest.java
+++ b/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoaderManualTest.java
@@ -3,6 +3,7 @@ package com.h3xstream.retirejs.repo;
 import com.esotericsoftware.minlog.Log;
 
 import java.io.IOException;
+import org.json.JSONException;
 
 import static org.testng.Assert.assertTrue;
 
@@ -10,7 +11,7 @@ import static org.testng.Assert.assertTrue;
  * Used to test the lookup of the remote repository.
  */
 public class VulnerabilitiesRepositoryLoaderManualTest {
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, JSONException {
         Log.DEBUG();
 
         VulnerabilitiesRepositoryLoader.syncWithOnlineRepository = true;

--- a/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoaderTest.java
+++ b/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoaderTest.java
@@ -6,6 +6,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import org.json.JSONException;
 
 import static org.testng.Assert.assertTrue;
 
@@ -17,7 +18,7 @@ public class VulnerabilitiesRepositoryLoaderTest {
     }
 
     @Test
-    public void testRepositoryLoad() throws IOException {
+    public void testRepositoryLoad() throws IOException, JSONException {
         VulnerabilitiesRepositoryLoader.syncWithOnlineRepository = false;
 
 
@@ -29,7 +30,7 @@ public class VulnerabilitiesRepositoryLoaderTest {
 
 
     @Test(enabled=true) //Not sure if this test should be kept enabled by default since it create file in user dir
-    public void testRepositoryLoadRemote() throws IOException {
+    public void testRepositoryLoadRemote() throws IOException, JSONException {
         VulnerabilitiesRepositoryLoader.syncWithOnlineRepository = true;
 
 

--- a/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositorySearchByContentTest.java
+++ b/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositorySearchByContentTest.java
@@ -9,13 +9,14 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.h3xstream.retirejs.repo.PrettyDisplay.displayResults;
+import org.json.JSONException;
 import static org.testng.Assert.assertEquals;
 
 public class VulnerabilitiesRepositorySearchByContentTest {
     VulnerabilitiesRepository repo;
 
     @BeforeClass
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, JSONException {
         Log.DEBUG();
 
         VulnerabilitiesRepositoryLoader.syncWithOnlineRepository = true;

--- a/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositorySearchByFilenameTest.java
+++ b/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositorySearchByFilenameTest.java
@@ -8,13 +8,14 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.h3xstream.retirejs.repo.PrettyDisplay.displayResults;
+import org.json.JSONException;
 import static org.testng.Assert.assertEquals;
 
 public class VulnerabilitiesRepositorySearchByFilenameTest {
     VulnerabilitiesRepository repo;
 
     @BeforeClass
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, JSONException {
         Log.DEBUG();
 
         VulnerabilitiesRepositoryLoader.syncWithOnlineRepository = true;

--- a/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositorySearchByHashTest.java
+++ b/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositorySearchByHashTest.java
@@ -1,8 +1,6 @@
 package com.h3xstream.retirejs.repo;
 
 import com.esotericsoftware.minlog.Log;
-import com.h3xstream.retirejs.util.HashUtil;
-import org.apache.commons.io.IOUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -10,6 +8,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.h3xstream.retirejs.repo.PrettyDisplay.displayResults;
+import org.json.JSONException;
 import static org.testng.Assert.assertEquals;
 
 public class VulnerabilitiesRepositorySearchByHashTest {
@@ -17,7 +16,7 @@ public class VulnerabilitiesRepositorySearchByHashTest {
     VulnerabilitiesRepository repo;
 
     @BeforeClass
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, JSONException {
         Log.DEBUG();
 
         VulnerabilitiesRepositoryLoader.syncWithOnlineRepository = true;

--- a/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositorySearchByUriTest.java
+++ b/retirejs-core/src/test/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositorySearchByUriTest.java
@@ -8,8 +8,8 @@ import java.io.IOException;
 import java.util.List;
 
 import static com.h3xstream.retirejs.repo.PrettyDisplay.displayResults;
+import org.json.JSONException;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Test the class VulnerabilitiesRepository
@@ -19,7 +19,7 @@ public class VulnerabilitiesRepositorySearchByUriTest {
     VulnerabilitiesRepository repo;
 
     @BeforeClass
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, JSONException {
         Log.DEBUG();
 
         VulnerabilitiesRepositoryLoader.syncWithOnlineRepository = true;

--- a/retirejs-maven-plugin/pom.xml
+++ b/retirejs-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>

--- a/retirejs-zap-plugin/pom.xml
+++ b/retirejs-zap-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <zap.addon.version>3</zap.addon.version>
+        <zap.addon.version>3.0.3</zap.addon.version>
         <zap.addon.status>alpha</zap.addon.status>
     </properties>
 
@@ -128,8 +128,8 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/retirejs-zap-plugin/pom.xml
+++ b/retirejs-zap-plugin/pom.xml
@@ -68,7 +68,24 @@
                             </execution>
                         </executions>
                     </plugin>
-
+                    <plugin>
+                        <groupId>com.coderplus.maven.plugins</groupId>
+                        <artifactId>copy-rename-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>copy-file</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceFile>${project.build.directory}\retirejs-${zap.addon.status}-${zap.addon.version}.jar</sourceFile>
+                                    <destinationFile>${project.build.directory}\retirejs-${zap.addon.status}-${zap.addon.version}.zap</destinationFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
 

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/RetireJsScannerPlugin.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/RetireJsScannerPlugin.java
@@ -15,6 +15,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 import java.io.IOException;
 import java.util.List;
+import org.json.JSONException;
 
 public class RetireJsScannerPlugin extends PluginPassiveScanner {
 
@@ -68,19 +69,19 @@ public class RetireJsScannerPlugin extends PluginPassiveScanner {
             }
         } catch (URIException e) {
             logger.error("Unable to scan the script '"+uri.toString()+"': "+e.getMessage(),e);
-        } catch (IOException e) {
+        } catch (IOException | JSONException e) {
             logger.error("Unable to scan the script '"+uri.toString()+"': "+e.getMessage(),e);
         }
     }
 
-    private void scanJavaScriptFile(String scriptName,int refId,HttpMessage httpMessage) throws IOException {
+    private void scanJavaScriptFile(String scriptName,int refId,HttpMessage httpMessage) throws IOException, JSONException {
         List<JsLibraryResult> librariesVuln = ScannerFacade.getInstance().scanScript(scriptName, httpMessage.getResponseBody().getBytes(), 0);
         for(JsLibraryResult libVuln : librariesVuln) {
             Alert newAlert = ZapIssueCreator.convertBugToAlert(PLUGIN_ID, libVuln, httpMessage);
             this.parent.raiseAlert(refId, newAlert);
         }
     }
-    private void scanHtmlFile(String scriptName,int refId,HttpMessage httpMessage) throws IOException {
+    private void scanHtmlFile(String scriptName,int refId,HttpMessage httpMessage) throws IOException, JSONException {
         List<JsLibraryResult> librariesVuln = ScannerFacade.getInstance().scanHtml(httpMessage.getResponseBody().getBytes(), 0);
         for(JsLibraryResult libVuln : librariesVuln) {
             Alert newAlert = ZapIssueCreator.convertBugToAlert(PLUGIN_ID, libVuln, httpMessage);

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
@@ -53,20 +53,24 @@ public class ZapIssueCreator {
         String evidence = "";
         String responseRegex = lib.getRegexResponse() == null ? "" : lib.getRegexResponse();
         if (!responseRegex.isEmpty()) {
-            String respBody = message.getResponseBody().toString();
-            Matcher respMatcher = Pattern.compile(responseRegex).matcher(respBody);
-            if (respMatcher.find()) {
-                evidence = respMatcher.group(0);
-            }
+            evidence = getSpecificEvidence(responseRegex, message.getResponseBody().toString());
         }
-        if (evidence.isEmpty()) { // The match wasn't from the response, try the request
+        if (evidence.isEmpty()) { // The match wasn't from the response, try the request URI
             String requestRegex = lib.getRegexRequest() == null ? "" : lib.getRegexRequest();
             if (!requestRegex.isEmpty()) {
-                String reqUri = message.getRequestHeader().getURI().toString();
-                Matcher reqMatcher = Pattern.compile(requestRegex).matcher(reqUri);
-                if (reqMatcher.find()) {
-                    evidence = reqMatcher.group(0);
-                }
+                evidence = getSpecificEvidence(requestRegex,
+                        message.getRequestHeader().getURI().toString());
+            }
+        }
+        return evidence;
+    }
+
+    private static String getSpecificEvidence(String regex, String content) {
+        String evidence = "";
+        if (!regex.isEmpty()) {
+            Matcher matcher = Pattern.compile(regex).matcher(content);
+            if (matcher.find()) {
+                evidence = matcher.group(0);
             }
         }
         return evidence;

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
@@ -49,8 +49,7 @@ public class ZapIssueCreator {
     }
 
     private static String getEvidence(JsLibraryResult lib, HttpMessage message) {
-        String evidence = "";
-        evidence = getSpecificEvidence(lib.getRegexResponse(),
+        String evidence = getSpecificEvidence(lib.getRegexResponse(),
                 message.getResponseBody().toString());
         if (evidence.isEmpty()) { // The match wasn't from the response, try the request URI
             evidence = getSpecificEvidence(lib.getRegexRequest(),

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
@@ -50,22 +50,18 @@ public class ZapIssueCreator {
 
     private static String getEvidence(JsLibraryResult lib, HttpMessage message) {
         String evidence = "";
-        String responseRegex = lib.getRegexResponse() == null ? "" : lib.getRegexResponse();
-        if (!responseRegex.isEmpty()) {
-            evidence = getSpecificEvidence(responseRegex, message.getResponseBody().toString());
-        }
+        evidence = getSpecificEvidence(lib.getRegexResponse(),
+                message.getResponseBody().toString());
         if (evidence.isEmpty()) { // The match wasn't from the response, try the request URI
-            String requestRegex = lib.getRegexRequest() == null ? "" : lib.getRegexRequest();
-            if (!requestRegex.isEmpty()) {
-                evidence = getSpecificEvidence(requestRegex,
-                        message.getRequestHeader().getURI().toString());
-            }
+            evidence = getSpecificEvidence(lib.getRegexRequest(),
+                    message.getRequestHeader().getURI().toString());
         }
         return evidence;
     }
 
     private static String getSpecificEvidence(String regex, String content) {
         String evidence = "";
+        regex = regex == null ? "" : regex;
         if (!regex.isEmpty()) {
             Matcher matcher = Pattern.compile(regex).matcher(content);
             if (matcher.find()) {

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
@@ -33,7 +33,6 @@ public class ZapIssueCreator {
                 lib.getVuln().getBelow());
 
         Alert alert = new Alert(pluginId, mapToZapSeverity(lib.getVuln().getSeverity()), Alert.CONFIDENCE_MEDIUM, title);
-        String evidence = getEvidence(lib, message);
         alert.setDetail(description,
                 message.getRequestHeader().getURI().toString(),
                 "", //Param
@@ -41,7 +40,7 @@ public class ZapIssueCreator {
                 otherInfo, //Other info
                 "Update the JavaScript library", //Solution
                 joinStrings(lib.getVuln().getInfo()), //Only one line is allow
-                evidence, //Evidence
+                getEvidence(lib, message), //Evidence
                 -1, //cweId
                 -1, //wascId
                 message

--- a/test-samples/http_server.py
+++ b/test-samples/http_server.py
@@ -4,5 +4,5 @@ import SocketServer
 Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
 httpd = SocketServer.TCPServer(("", 8000), Handler)
 
-print "Server started"
+print("Server started")
 httpd.serve_forever()


### PR DESCRIPTION
- Replace non-free dependency https://github.com/h3xstream/burp-retire-js/issues/61
- Updated the RetireJS built-in repository https://github.com/h3xstream/burp-retire-js/issues/63
- Minor dependencies update