### PR TITLE
Log the fact of successful plugin load

### DIFF
--- a/retirejs-burp-plugin/src/main/java/burp/BurpExtender.java
+++ b/retirejs-burp-plugin/src/main/java/burp/BurpExtender.java
@@ -73,6 +73,8 @@ public class BurpExtender implements IBurpExtender, IScannerCheck {
 
         //Not fully implemented (the passive scan rule is sufficient)
         //callbacks.registerMessageEditorTabFactory(this);
+        
+        stdout.println("Retire.js plugin loaded");
     }
 
 


### PR DESCRIPTION
Unfortunately Burp Suite API doesn't provide any facilities to check plugin states in runtime. The only way to automate these things is to monitor output of the plugin, but Retire.js doesn't report anything useful after being loaded. It wouldn't be a problem if the plugin loaded immediately, but it preloads vulnerabilities from outside and it could take a while. This commit just prints a message to the stdout after plugin load.